### PR TITLE
Add CI workflow for Clarion simulator tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,25 +23,22 @@ jobs:
           sudo apt-get install -y -q swi-prolog
 
       - name: Install Logtalk
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Get latest Logtalk release
-          LOGTALK_VERSION=$(curl -s https://api.github.com/repos/LogtalkDotOrg/logtalk3/releases/latest | grep tag_name | cut -d '"' -f 4)
+          # Get latest Logtalk release tag using gh cli (handles auth)
+          LOGTALK_VERSION=$(gh api repos/LogtalkDotOrg/logtalk3/releases/latest --jq '.tag_name')
+          if [ -z "$LOGTALK_VERSION" ]; then
+            echo "ERROR: Failed to get Logtalk version"
+            exit 1
+          fi
           echo "Installing Logtalk ${LOGTALK_VERSION}"
           curl -sL "https://github.com/LogtalkDotOrg/logtalk3/archive/refs/tags/${LOGTALK_VERSION}.tar.gz" -o logtalk.tar.gz
           tar xzf logtalk.tar.gz
           cd logtalk3-*/
           sudo cp -r . /usr/local/share/logtalk
-          # Set up Logtalk environment
-          export LOGTALKHOME=/usr/local/share/logtalk
-          export LOGTALKUSER=$HOME/logtalk
-          mkdir -p "$LOGTALKUSER"
-          cp -r "$LOGTALKHOME/adapters" "$LOGTALKUSER/"
-          cp -r "$LOGTALKHOME/core" "$LOGTALKUSER/"
-          cp -r "$LOGTALKHOME/paths" "$LOGTALKUSER/"
-          cp -r "$LOGTALKHOME/library" "$LOGTALKUSER/"
-          cp -r "$LOGTALKHOME/tools" "$LOGTALKUSER/"
           # Install SWI-Prolog integration
-          cd "$LOGTALKHOME/integration"
+          cd /usr/local/share/logtalk/integration
           if [ -f swilgt.sh ]; then
             sudo cp swilgt.sh /usr/local/bin/swilgt
             sudo chmod +x /usr/local/bin/swilgt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main, 'feature/**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  prolog-simulator-tests:
+    name: Clarion Simulator Tests (SWI-Prolog + Logtalk)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install SWI-Prolog
+        run: |
+          sudo apt-add-repository -y ppa:swi-prolog/stable
+          sudo apt-get update -q
+          sudo apt-get install -y -q swi-prolog
+
+      - name: Install Logtalk
+        run: |
+          # Get latest Logtalk release
+          LOGTALK_VERSION=$(curl -s https://api.github.com/repos/LogtalkDotOrg/logtalk3/releases/latest | grep tag_name | cut -d '"' -f 4)
+          echo "Installing Logtalk ${LOGTALK_VERSION}"
+          curl -sL "https://github.com/LogtalkDotOrg/logtalk3/archive/refs/tags/${LOGTALK_VERSION}.tar.gz" -o logtalk.tar.gz
+          tar xzf logtalk.tar.gz
+          cd logtalk3-*/
+          sudo cp -r . /usr/local/share/logtalk
+          # Set up Logtalk environment
+          export LOGTALKHOME=/usr/local/share/logtalk
+          export LOGTALKUSER=$HOME/logtalk
+          mkdir -p "$LOGTALKUSER"
+          cp -r "$LOGTALKHOME/adapters" "$LOGTALKUSER/"
+          cp -r "$LOGTALKHOME/core" "$LOGTALKUSER/"
+          cp -r "$LOGTALKHOME/paths" "$LOGTALKUSER/"
+          cp -r "$LOGTALKHOME/library" "$LOGTALKUSER/"
+          cp -r "$LOGTALKHOME/tools" "$LOGTALKUSER/"
+          # Install SWI-Prolog integration
+          cd "$LOGTALKHOME/integration"
+          if [ -f swilgt.sh ]; then
+            sudo cp swilgt.sh /usr/local/bin/swilgt
+            sudo chmod +x /usr/local/bin/swilgt
+          fi
+
+      - name: Verify SWI-Prolog
+        run: swipl --version
+
+      - name: Run unified simulator tests
+        working-directory: simulators/clarion/unified
+        env:
+          LOGTALKHOME: /usr/local/share/logtalk
+          LOGTALKUSER: ${{ github.workspace }}/logtalk_user
+        run: |
+          # Set up Logtalk user directory
+          mkdir -p "$LOGTALKUSER"
+          cp -r "$LOGTALKHOME/adapters" "$LOGTALKUSER/"
+          cp -r "$LOGTALKHOME/core" "$LOGTALKUSER/"
+          cp -r "$LOGTALKHOME/paths" "$LOGTALKUSER/"
+          cp -r "$LOGTALKHOME/library" "$LOGTALKUSER/"
+          cp -r "$LOGTALKHOME/tools" "$LOGTALKUSER/"
+
+          # Run tests — exits 1 on any failure
+          swipl -g "main,halt" -t "halt(1)" test_unified.pl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,11 @@ jobs:
           sudo apt-get install -y -q swi-prolog
 
       - name: Install Logtalk
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          # Get latest Logtalk release tag using gh cli (handles auth)
-          LOGTALK_VERSION=$(gh api repos/LogtalkDotOrg/logtalk3/releases/latest --jq '.tag_name')
-          if [ -z "$LOGTALK_VERSION" ]; then
-            echo "ERROR: Failed to get Logtalk version"
-            exit 1
-          fi
+          # Pin a known stable version to avoid API calls entirely
+          LOGTALK_VERSION="lgt3840stable"
           echo "Installing Logtalk ${LOGTALK_VERSION}"
-          curl -sL "https://github.com/LogtalkDotOrg/logtalk3/archive/refs/tags/${LOGTALK_VERSION}.tar.gz" -o logtalk.tar.gz
+          curl -sfL "https://github.com/LogtalkDotOrg/logtalk3/archive/refs/tags/${LOGTALK_VERSION}.tar.gz" -o logtalk.tar.gz
           tar xzf logtalk.tar.gz
           cd logtalk3-*/
           sudo cp -r . /usr/local/share/logtalk


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs the unified Clarion simulator tests on push/PR
- Installs SWI-Prolog and Logtalk on Ubuntu, then runs `test_unified.pl` (104 tests)
- Triggers on pushes to `main` and `feature/**` branches, and on PRs to `main`

## Test plan
- [ ] Verify the workflow runs successfully on this PR
- [ ] Confirm SWI-Prolog and Logtalk install correctly in CI
- [ ] Confirm all 104 unified simulator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)